### PR TITLE
Add support for Clojure's reader macros

### DIFF
--- a/symex-interface-clojure.el
+++ b/symex-interface-clojure.el
@@ -75,6 +75,20 @@ Accounts for different point location in evil vs Emacs mode."
   "Evaluate buffer."
   (cider-eval-buffer))
 
+(defun symex-clojure-comment-remaining-reader-macro ()
+  "Comment out remaining symexes at this level using clojure's comment reader macro."
+  (interactive)
+  (let ((count (symex--remaining-length)))
+    (my-symex-comment-reader-macro count)))
+
+(defun symex-clojure-comment-reader-macro (count)
+  "Comment symex using clojure's comment reader macro"
+  (interactive "p")
+  (dotimes (_ count)
+    (insert "#_")
+    (when (not (symex--go-forward))
+      (backward-char 2))))
+
 
 (provide 'symex-interface-clojure)
 ;;; symex-interface-clojure.el ends here


### PR DESCRIPTION
### Summary of Changes

Clojure has a number of reader macros, some of which have differing syntax to other lisps. This PR adds support for the unique reader macros.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.