### PR TITLE
Add symex--special-left-p case for Clojure(script) deref reader macro

### DIFF
--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -170,11 +170,11 @@
   (looking-at (concat "," lispy-left)))
 
 (defun symex--clojure-deref-reader-macro-p ()
-  "Check if the symex is a clojure(script) deref reader macro."
+  "Check if the symex is a clojure deref reader macro."
   (looking-at (concat "@" lispy-left)))
 
 (defun symex--clojure-literal-lambda-p ()
-  "Check if the symex is a clojure(script) anonymous function literal."
+  "Check if the symex is a clojure anonymous function literal."
   (looking-at (concat "#" lispy-left)))
 
 (defun symex--special-left-p ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -200,7 +200,9 @@ as special cases here."
              (progn (forward-char 4)
                     (lispy-right-p))))
       (save-excursion
-        (and (or (symex--quoted-list-p) (symex--clojure-literal-lambda-p))
+        (and (or (symex--quoted-list-p)
+                 (symex--clojure-deref-reader-macro-p)
+                 (symex--clojure-literal-lambda-p))
              (progn (forward-char 3)
                     (lispy-right-p))))))
 
@@ -348,6 +350,7 @@ of symex mode (use the public `symex-go-backward` instead)."
            (forward-char 4))
           ((and (or (symex--quoted-list-p)
                     (symex--unquoted-list-p)
+                    (symex--clojure-deref-reader-macro-p)
                     (symex--clojure-literal-lambda-p))
                 (not (symex--special-empty-list-p)))
            (forward-char 2))
@@ -382,6 +385,8 @@ of symex mode (use the public `symex-go-up` instead)."
              (cond ((looking-back "#['`]" (line-beginning-position))
                     (backward-char 2))
                    ((looking-back "[#'`]" (line-beginning-position))
+                    (backward-char))
+                   ((looking-back "@" (line-beginning-position))
                     (backward-char)))
              1)
     (error 0)))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -169,8 +169,12 @@
   "Check if the symex is an unquoted list."
   (looking-at (concat "," lispy-left)))
 
+(defun symex--clojure-deref-reader-macro-p ()
+  "Check if the symex is a clojure(script) deref reader macro."
+  (looking-at (concat "@" lispy-left)))
+
 (defun symex--clojure-literal-lambda-p ()
-  "Check if the symex is a clojurescript anonymous function literal."
+  "Check if the symex is a clojure(script) anonymous function literal."
   (looking-at (concat "#" lispy-left)))
 
 (defun symex--special-left-p ()
@@ -186,6 +190,7 @@ as special cases here."
       (symex--racket-syntax-object-p)
       (symex--splicing-unquote-p)
       (symex--racket-splicing-unsyntax-p)
+      (symex--clojure-deref-reader-macro-p)
       (symex--clojure-literal-lambda-p)))
 
 (defun symex--special-empty-list-p ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -170,11 +170,11 @@
   (looking-at (concat "," lispy-left)))
 
 (defun symex--clojure-deref-reader-macro-p ()
-  "Check if the symex is a clojure deref reader macro."
+  "Check if the symex is a Clojure deref reader macro."
   (looking-at (concat "@" lispy-left)))
 
 (defun symex--clojure-literal-lambda-p ()
-  "Check if the symex is a clojure anonymous function literal."
+  "Check if the symex is a Clojure anonymous function literal."
   (looking-at (concat "#" lispy-left)))
 
 (defun symex--special-left-p ()


### PR DESCRIPTION
### Summary of Changes

Clojure has a short [deref reader macro](https://clojure.org/reference/reader#_deref) that is just syntax sugar. When used on a symbol (`@a-ref`) symex.el behaves as expected. However, use on an expression doesn't behave like how I would expect.

(This was initially made as a PR [here](https://github.com/countvajhula/symex.el/pull/34), apologies but I made that off `master` and couldn't work out a way to change the head branch in GH's PR workflow)

### Given
```
(do |@(function-returning-a-ref)
    (another-symex))
```

#### Down
`j` →

##### Current
```
(do |@(function-returning-a-ref)
    (another-symex))
```

##### Expected
```
(do @(|function-returning-a-ref)
    (another-symex))
```

#### Forward
`f` →

##### Current
```
(do @(function-returning-a-ref)
    |(another-symex))
```

##### Expected
```
(do @(|function-returning-a-ref)
    (another-symex))
```

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
