### PR TITLE
Correct repo name for melpazoid runner

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         LOCAL_REPO: ${{ github.workspace }}
         # RECIPE is your recipe as written for MELPA:
-        RECIPE: (symex :repo "countvajhula/symex" :fetcher github)
+        RECIPE: (symex :repo "countvajhula/symex.el" :fetcher github)
         # set this to false (or remove it) if the package isn't on MELPA:
         EXIST_OK: true
       run: echo $GITHUB_REF && make -C ~/melpazoid


### PR DESCRIPTION
### Summary of Changes

The melpazoid workflow is currently failing https://github.com/countvajhula/symex.el/runs/4296416541?check_suite_focus=true#step:5:48 

I believe this is the correct repo name.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.