### PR TITLE
Symex ts fix leap branch

### DIFF
--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -91,7 +91,7 @@ Syntax
 Description
 ```````````
 
-Execute a sequence of traversals in order. If the maneuver is partially completed, i.e. if at least one traversal was executed, then the maneuver is treated as successful. Otherwise it is considered to have failed.
+Execute a sequence of traversals in order. The maneuver succeeds if *all* of the traversals succeed. If any of them fail, then the entire maneuver is aborted and nothing happens. In other words, the maneuver has "all or nothing" semantics. To accept partial completion, use ``venture`` instead.
 
 Examples
 ````````
@@ -115,6 +115,42 @@ Examples
       (maneuver (maneuver (move up)
                           (circuit (move forward)))
                 (move up))))
+
+venture
+~~~~~~~
+
+Syntax
+``````
+
+``(venture traversal ...)``
+
+Description
+```````````
+
+Execute a sequence of traversals in order. If the venture is partially completed, i.e. if at least one traversal was executed, then the venture is treated as successful. Otherwise it is considered to have failed.
+
+Examples
+````````
+
+"Venture to go forward, then up, and then forward again."
+
+::
+
+  (symex-execute-traversal
+    (symex-traversal
+      (venture (move forward)
+               (move up)
+               (move forward))))
+
+"Venture to go up and then keep going forward, and then go up again."
+
+::
+
+  (symex-execute-traversal
+    (symex-traversal
+      (venture (venture (move up)
+                        (circuit (move forward)))
+               (move up))))
 
 protocol
 ~~~~~~~~
@@ -269,8 +305,8 @@ Examples
     (symex-traversal
       (circuit
         (precaution
-          (maneuver (move down)
-                    (move forward))
+          (venture (move down)
+                   (move forward))
           (afterwards (not (at root)))))))
 
 precaution
@@ -414,6 +450,6 @@ Also see `this series on ELisp debugging <https://endlessparentheses.com/debuggi
 Gotchas
 ^^^^^^^
 
-The ``symex-traversal`` form accepts a *single* traversal argument. If you'd like to do more than one thing, then wrap the steps in a `maneuver`_.
+The ``symex-traversal`` form accepts a *single* traversal argument. If you'd like to do more than one thing, then wrap the steps in a `maneuver`_ or a `venture`_.
 
 ``symex-deftraversal`` is equivalent to ``(defvar name (symex-traversal traversal))``. As it uses ``defvar``, once defined, you cannot use the same form to redefine the traversal (e.g. if you are debugging it). You will need to use ``setq`` directly -- e.g. replace ``defvar`` with ``setq`` in the expanded version of this form.

--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -447,6 +447,18 @@ When you're done debugging, you can remove the debugger hooks by just evaluating
 
 Also see `this series on ELisp debugging <https://endlessparentheses.com/debugging-emacs-lisp-part-1-earn-your-independence.html>`__ for more tips.
 
+Print Statements and Asserts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Don't hesitate to add print statements (e.g. ``message``) to trace the execution path. Such trace logs can also serve as evidence from which to form hypotheses about bugs. You could also use ``cl-assert`` to assert assumptions at specific points.
+
+Minimizing Complexity
+^^^^^^^^^^^^^^^^^^^^^
+
+Symex uses advice to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
+
+It may also be advisable to comment out macros like ``symex-save-excursion`` to see if the problem persists.
+
 Gotchas
 ^^^^^^^
 

--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -455,7 +455,7 @@ Don't hesitate to add print statements (e.g. ``message``) to trace the execution
 Minimizing Complexity
 ^^^^^^^^^^^^^^^^^^^^^
 
-Symex uses advice to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
+Symex uses `advice <https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html>`_ to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
 
 It may also be advisable to comment out macros like ``symex-save-excursion`` to see if the problem persists.
 

--- a/symex-data.el
+++ b/symex-data.el
@@ -166,6 +166,41 @@ This is useful for structural recursion during circuit execution."
         (times (symex--circuit-times circuit)))
     (symex-make-circuit traversal (when times (1- times)))))
 
+(defun symex-make-maneuver (&rest phases)
+  "Construct a maneuver from the given PHASES."
+  (list 'maneuver
+        phases))
+
+(defun symex-maneuver-p (obj)
+  "Check if OBJ specifies a maneuver."
+  (condition-case nil
+      (equal 'maneuver
+             (nth 0 obj))
+    (error nil)))
+
+(defun symex--maneuver-phases (maneuver)
+  "Get the phases of a MANEUVER.
+
+Each phase could be any traversal."
+  (nth 1 maneuver))
+
+(defun symex--maneuver-null-p (maneuver)
+  "Check if MANEUVER is empty or null."
+  (null (symex--maneuver-phases maneuver)))
+
+(defun symex--maneuver-first (maneuver)
+  "Get the first phase of a MANEUVER.
+
+This is useful for structural recursion during maneuver execution."
+  (car (symex--maneuver-phases maneuver)))
+
+(defun symex--maneuver-rest (maneuver)
+  "A maneuver defined from the remaining phases in MANEUVER not counting the first.
+
+This is useful for structural recursion during maneuver execution."
+  (apply #'symex-make-maneuver
+         (cdr (symex--maneuver-phases maneuver))))
+
 (defun symex-make-venture (&rest phases)
   "Construct a venture from the given PHASES."
   (list 'venture
@@ -307,6 +342,7 @@ This is the traversal that will be chosen if the condition is false."
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)
+      (symex-maneuver-p obj)
       (symex-venture-p obj)
       (symex-circuit-p obj)
       (symex-detour-p obj)

--- a/symex-data.el
+++ b/symex-data.el
@@ -56,6 +56,10 @@ forward-backward axis, and the Y or in-out axis."
     (error nil)))
 
 (defconst symex--move-zero (symex-make-move 0 0))
+(defconst symex--move-forward (symex-make-move 1 0))
+(defconst symex--move-backward (symex-make-move -1 0))
+(defconst symex--move-down (symex-make-move 0 -1))
+(defconst symex--move-up (symex-make-move 0 1))
 
 (defun symex--are-moves-equal-p (m1 m2)
   "Check if two moves M1 and M2 are identical."

--- a/symex-data.el
+++ b/symex-data.el
@@ -22,8 +22,8 @@
 ;;; Commentary:
 
 ;; Data abstractions for symex mode.  Defines the linguistic primitives
-;; of the symex DSL: moves, maneuvers, precautions, protocols,
-;; circuits, and detours.
+;; of the symex DSL: moves, maneuvers, ventures, precautions, protocols,
+;; decisions, circuits, and detours.
 
 ;;; Code:
 
@@ -166,40 +166,40 @@ This is useful for structural recursion during circuit execution."
         (times (symex--circuit-times circuit)))
     (symex-make-circuit traversal (when times (1- times)))))
 
-(defun symex-make-maneuver (&rest phases)
-  "Construct a maneuver from the given PHASES."
-  (list 'maneuver
+(defun symex-make-venture (&rest phases)
+  "Construct a venture from the given PHASES."
+  (list 'venture
         phases))
 
-(defun symex-maneuver-p (obj)
-  "Check if OBJ specifies a maneuver."
+(defun symex-venture-p (obj)
+  "Check if OBJ specifies a venture."
   (condition-case nil
-      (equal 'maneuver
+      (equal 'venture
              (nth 0 obj))
     (error nil)))
 
-(defun symex--maneuver-phases (maneuver)
-  "Get the phases of a MANEUVER.
+(defun symex--venture-phases (venture)
+  "Get the phases of a VENTURE.
 
 Each phase could be any traversal."
-  (nth 1 maneuver))
+  (nth 1 venture))
 
-(defun symex--maneuver-null-p (maneuver)
-  "Check if MANEUVER is empty or null."
-  (null (symex--maneuver-phases maneuver)))
+(defun symex--venture-null-p (venture)
+  "Check if VENTURE is empty or null."
+  (null (symex--venture-phases venture)))
 
-(defun symex--maneuver-first (maneuver)
-  "Get the first phase of a MANEUVER.
+(defun symex--venture-first (venture)
+  "Get the first phase of a VENTURE.
 
-This is useful for structural recursion during maneuver execution."
-  (car (symex--maneuver-phases maneuver)))
+This is useful for structural recursion during venture execution."
+  (car (symex--venture-phases venture)))
 
-(defun symex--maneuver-rest (maneuver)
-  "A maneuver defined from the remaining phases in MANEUVER not counting the first.
+(defun symex--venture-rest (venture)
+  "A venture defined from the remaining phases in VENTURE not counting the first.
 
-This is useful for structural recursion during maneuver execution."
-  (apply #'symex-make-maneuver
-         (cdr (symex--maneuver-phases maneuver))))
+This is useful for structural recursion during venture execution."
+  (apply #'symex-make-venture
+         (cdr (symex--venture-phases venture))))
 
 (defun symex-make-detour (reorientation traversal)
   "Construct a detour.
@@ -234,7 +234,7 @@ fails as well."
 (defun symex-make-protocol (&rest options)
   "Construct a protocol abstraction for the given OPTIONS.
 
-An option could be either a maneuver, or a protocol itself."
+Each option could be any traversal."
   (list 'protocol
         options))
 
@@ -307,7 +307,7 @@ This is the traversal that will be chosen if the condition is false."
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)
-      (symex-maneuver-p obj)
+      (symex-venture-p obj)
       (symex-circuit-p obj)
       (symex-detour-p obj)
       (symex-precaution-p obj)

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -219,6 +219,7 @@ This can be thought of as the 'program' written in the DSL, which
 will be compiled into Lisp and can be executed when needed.
 An optional DOCSTRING will be used as documentation for the variable
 NAME to which the traversal is assigned."
+  (declare (indent 1))
   `(defvar ,name (symex-traversal ,traversal) ,docstring))
 
 

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -40,11 +40,11 @@ OPTIONS - see underlying Lisp implementation."
   `(symex-make-protocol
     ,@(mapcar #'symex--compile-traversal-helper options)))
 
-(defmacro symex--compile-maneuver (&rest phases)
-  "Compile a maneuver from Symex DSL -> Lisp.
+(defmacro symex--compile-venture (&rest phases)
+  "Compile a venture from Symex DSL -> Lisp.
 
 PHASES - see underlying Lisp implementation."
-  `(symex-make-maneuver
+  `(symex-make-venture
     ,@(mapcar #'symex--compile-traversal-helper phases)))
 
 (defmacro symex--compile-detour (reorientation traversal)
@@ -195,8 +195,8 @@ a detour, a move, etc., which is specified using the Symex DSL."
   (cond ((not (listp traversal)) traversal)  ; e.g. a variable containing a traversal
         ((equal 'protocol (car traversal))
          `(symex--compile-protocol ,@(cdr traversal)))
-        ((equal 'maneuver (car traversal))
-         `(symex--compile-maneuver ,@(cdr traversal)))
+        ((equal 'venture (car traversal))
+         `(symex--compile-venture ,@(cdr traversal)))
         ((equal 'detour (car traversal))
          `(symex--compile-detour ,@(cdr traversal)))
         ((equal 'circuit (car traversal))

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -40,6 +40,13 @@ OPTIONS - see underlying Lisp implementation."
   `(symex-make-protocol
     ,@(mapcar #'symex--compile-traversal-helper options)))
 
+(defmacro symex--compile-maneuver (&rest phases)
+  "Compile a maneuver from Symex DSL -> Lisp.
+
+PHASES - see underlying Lisp implementation."
+  `(symex-make-maneuver
+    ,@(mapcar #'symex--compile-traversal-helper phases)))
+
 (defmacro symex--compile-venture (&rest phases)
   "Compile a venture from Symex DSL -> Lisp.
 
@@ -195,6 +202,8 @@ a detour, a move, etc., which is specified using the Symex DSL."
   (cond ((not (listp traversal)) traversal)  ; e.g. a variable containing a traversal
         ((equal 'protocol (car traversal))
          `(symex--compile-protocol ,@(cdr traversal)))
+        ((equal 'maneuver (car traversal))
+         `(symex--compile-maneuver ,@(cdr traversal)))
         ((equal 'venture (car traversal))
          `(symex--compile-venture ,@(cdr traversal)))
         ((equal 'detour (car traversal))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -133,22 +133,22 @@ The aggregate result is constructed according to the specified COMPUTATION."
            a
            b))
 
-(defun symex-execute-maneuver (maneuver computation)
-  "Attempt to execute a given MANEUVER.
+(defun symex-execute-venture (venture computation)
+  "Attempt to execute a given VENTURE.
 
-Attempts the maneuver in the order of its phases.  If any phase fails,
-then the maneuver is terminated at that step.  The maneuver succeeds
+Attempts the venture in the order of its phases.  If any phase fails,
+then the venture is terminated at that step.  The venture succeeds
 if at least one phase succeeds, and otherwise fails.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (unless (symex--maneuver-null-p maneuver)
-    (let ((current-phase (symex--maneuver-first maneuver))
-          (remaining-maneuver (symex--maneuver-rest maneuver)))
+  (unless (symex--venture-null-p venture)
+    (let ((current-phase (symex--venture-first venture))
+          (remaining-venture (symex--venture-rest venture)))
       (let ((executed-phase (symex-execute-traversal current-phase
                                                      computation)))
         (when executed-phase
           (let ((executed-remaining-phases
-                 (symex-execute-traversal remaining-maneuver
+                 (symex-execute-traversal remaining-venture
                                           computation)))
             (symex--compute-results executed-phase
                                     executed-remaining-phases
@@ -267,9 +267,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
           (original-point-height-offset
            (symex-save-excursion
             (symex--point-height-offset)))
-          (executed-traversal (cond ((symex-maneuver-p traversal)
-                                     (symex-execute-maneuver traversal
-                                                             computation))
+          (executed-traversal (cond ((symex-venture-p traversal)
+                                     (symex-execute-venture traversal
+                                                            computation))
                                     ((symex-circuit-p traversal)
                                      (symex-execute-circuit traversal
                                                             computation))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -56,7 +56,8 @@ requiring changes to higher-level code that uses the present interface."
           ((> move-y 0)
            (symex--enter move-y))
           ((< move-y 0)
-           (symex--exit (abs move-y))))))
+           (symex--exit (abs move-y)))
+          (t symex--move-zero))))
 
 (defun symex-execute-move (move &optional computation)
   "Execute the MOVE as a traversal.

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -50,13 +50,13 @@ requiring changes to higher-level code that uses the present interface."
   (let ((move-x (symex--move-x move))
         (move-y (symex--move-y move)))
     (cond ((> move-x 0)
-           (symex--forward move-x))
+           (symex--go-forward move-x))
           ((< move-x 0)
-           (symex--backward (abs move-x)))
+           (symex--go-backward (abs move-x)))
           ((> move-y 0)
-           (symex--enter move-y))
+           (symex--go-up move-y))
           ((< move-y 0)
-           (symex--exit (abs move-y)))
+           (symex--go-down (abs move-y)))
           (t symex--move-zero))))
 
 (defun symex-execute-move (move &optional computation)
@@ -68,38 +68,6 @@ Optional argument COMPUTATION currently unused."
   (let ((executed-move (symex--execute-tree-move move computation)))
     (when executed-move
       (list executed-move))))
-
-(cl-defun symex--go-forward (&optional (count 1))
-  "Move forward COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move count 0)))
-
-(cl-defun symex--go-backward (&optional (count 1))
-  "Move backwards COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move (- count) 0)))
-
-(cl-defun symex--go-up (&optional (count 1))
-  "Move up COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move 0 count)))
-
-(cl-defun symex--go-down (&optional (count 1))
-  "Move down COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move 0 (- count))))
 
 (cl-defun symex-go-forward (&optional (count 1))
   "Move forward COUNT symexes."

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -292,6 +292,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
+          (symex-select-nearest)
           (let* ((current-point-height-offset (symex--point-height-offset))
                  (height-differential (- original-point-height-offset
                                          current-point-height-offset)))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -266,7 +266,14 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         (side-effect (if side-effect
                          side-effect
                        #'symex--side-effect-noop)))
+    ;; TODO: a macro similar to `symex-save-excursion`
+    ;; where it conditionally returns to the original
+    ;; point / node depending on whether BODY succeeds
+    ;; or which tests for success before moving point
     (let ((original-location (point))
+          (original-point-height-offset
+           (symex-save-excursion
+            (symex--point-height-offset)))
           (executed-traversal (cond ((symex-maneuver-p traversal)
                                      (symex-execute-maneuver traversal
                                                              computation))
@@ -295,6 +302,14 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
+          (let* ((current-point-height-offset
+                  (symex-save-excursion
+                   (symex--point-height-offset)))
+                 (height-differential (- original-point-height-offset
+                                         current-point-height-offset)))
+            ;; necessary because point does not uniquely identify
+            ;; a node for non-symex (i.e. tree-sitter) languages
+            (symex--go-up height-differential))
           result)))))
 
 

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -140,7 +140,8 @@ Attempts the maneuver in the order of its phases.  The maneuver
 succeeds only if all of the phases succeed, and otherwise fails.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (unless (symex--maneuver-null-p maneuver)
+  (if (symex--maneuver-null-p maneuver)
+      symex--move-zero
     (let ((current-phase (symex--maneuver-first maneuver))
           (remaining-maneuver (symex--maneuver-rest maneuver)))
       (let ((executed-phase (symex-execute-traversal current-phase
@@ -151,7 +152,10 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                           computation)))
             (when executed-remaining-phases
               (symex--compute-results executed-phase
-                                      executed-remaining-phases
+                                      (if (equal executed-remaining-phases
+                                                 (list symex--move-zero))
+                                          nil
+                                          executed-remaining-phases)
                                       computation))))))))
 
 (defun symex-execute-venture (venture computation)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -260,8 +260,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
     ;; or which tests for success before moving point
     (let ((original-location (point))
           (original-point-height-offset
-           (symex-save-excursion
-            (symex--point-height-offset)))
+           (symex--point-height-offset))
           (executed-traversal (cond ((symex-maneuver-p traversal)
                                      (symex-execute-maneuver traversal
                                                              computation))
@@ -293,9 +292,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
-          (let* ((current-point-height-offset
-                  (symex-save-excursion
-                   (symex--point-height-offset)))
+          (let* ((current-point-height-offset (symex--point-height-offset))
                  (height-differential (- original-point-height-offset
                                          current-point-height-offset)))
             ;; necessary because point does not uniquely identify

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -47,6 +47,7 @@
 
 (defun symex--adjust-point ()
   "Helper to adjust point to indicate the correct symex."
+  ;; TODO: needs review for tree-sitter
   (unless (or (bobp)
               (symex--point-at-start-p)
               (save-excursion (backward-char)  ; just inside symex

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -27,7 +27,8 @@
 
 ;;; Code:
 
-(require 'symex-custom)
+(require 'symex-custom
+         'symex-primitives)
 
 ;; to avoid byte compile warnings.  eventually sort out the dependency
 ;; order so this is unnecessary
@@ -44,16 +45,6 @@
 
 (defvar-local symex--original-scroll-margin nil)
 (defvar-local symex--original-max-scroll-margin nil)
-
-(defun symex--adjust-point ()
-  "Helper to adjust point to indicate the correct symex."
-  ;; TODO: needs review for tree-sitter
-  (unless (or (bobp)
-              (symex--point-at-start-p)
-              (save-excursion (backward-char)  ; just inside symex
-                              (or (lispy-left-p)
-                                  (symex-string-p))))
-    (backward-sexp)))
 
 (defun symex--adjust-point-on-entry ()
   "Adjust point context from the Emacs to the Vim interpretation.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -369,7 +369,10 @@ difference from the lowest such level."
 
 (defun symex--point-height-offset (&optional orig-pos)
   "Compute the height offset of the current symex from the lowest one indicated by point."
-  (if tree-sitter-mode
+  (if (and tree-sitter-mode (not (symex-ts--at-root-p)))
+      ;; don't attempt to calculate offset at the "real" root
+      ;; since offsets are typically computed while ignoring it
+      ;; i.e. they are wrt. "tree root"
       (let ((orig-pos (or orig-pos (point))))
         (symex--point-height-offset-helper orig-pos))
     0))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -496,31 +496,30 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (circuit (precaution traverse
-                                  (afterwards (not (lambda ()
-                                                     (= (symex-height)
-                                                        height))))))))
-           (run-along-neighboring-branch
-            (symex-traversal
              (maneuver (decision (at first)
-                                 find-neighboring-branch
-                                 (maneuver symex--traversal-goto-first
-                                           find-neighboring-branch))
+                                 symex--move-zero
+                                 symex--traversal-goto-first)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
                        traverse
-                       symex--traversal-goto-first
-                       (circuit (precaution (move forward)
-                                            (beforehand (lambda ()
-                                                          (< (symex-index)
-                                                             index)))))))))
+                       symex--traversal-goto-first)))
+           (run-along-branch
+            (symex-traversal
+             (circuit (precaution (move forward)
+                                  (beforehand (lambda ()
+                                                (< (symex-index)
+                                                   index)))))))
+           (leap-backward
+            (symex-traversal
+             (maneuver find-neighboring-branch
+                       run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver run-along-neighboring-branch
+        (precaution (maneuver leap-backward
                               (circuit
-                               (precaution (decision (lambda ()
-                                                       (< (symex-index)
-                                                          index))
-                                                     run-along-neighboring-branch
-                                                     symex--move-zero)
+                               (precaution leap-backward
                                            (beforehand (lambda ()
                                                          (< (symex-index)
                                                             index))))))
@@ -546,30 +545,29 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (circuit (precaution traverse
-                                  (afterwards (not (lambda ()
-                                                     (= (symex-height)
-                                                        height))))))))
-           (run-along-neighboring-branch
-            (symex-traversal
              (maneuver (decision (at last)
-                                 find-neighboring-branch
-                                 (maneuver symex--traversal-goto-last
-                                           find-neighboring-branch))
-                       traverse
-                       (circuit (precaution (move forward)
-                                            (beforehand (lambda ()
-                                                          (< (symex-index)
-                                                             index)))))))))
+                                 symex--move-zero
+                                 symex--traversal-goto-last)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse)))
+           (run-along-branch
+            (symex-traversal
+             (circuit (precaution (move forward)
+                                  (beforehand (lambda ()
+                                                (< (symex-index)
+                                                   index)))))))
+           (leap-forward
+            (symex-traversal
+             (maneuver find-neighboring-branch
+                       run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver run-along-neighboring-branch
+        (precaution (maneuver leap-forward
                               (circuit
-                               (precaution (decision (lambda ()
-                                                       (< (symex-index)
-                                                          index))
-                                                     run-along-neighboring-branch
-                                                     symex--move-zero)
+                               (precaution leap-forward
                                            (beforehand (lambda ()
                                                          (< (symex-index)
                                                             index))))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -400,33 +400,9 @@ location (e.g. non-symex-based languages like Python)."
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."
   (interactive)
-  (save-excursion
-    (symex-select-nearest)
-    (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-      (length moves))))
-
-;; (defun symex-height ()  ; TODO: may be better framed as a computation
-;;   "Get height (above root) of current symex."
-;;   (interactive)
-;;   (let ((result (save-excursion
-;;                   (symex-select-nearest)
-;;                   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-;;                     (length moves)))))
-;;     (when tree-sitter-mode
-;;       (symex-ts-set-current-node-from-point)
-;;       (let ((result2 (save-excursion
-;;                        (symex-select-nearest)
-;;                        (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-;;                          (length moves)))))
-;;         (symex-ts-set-current-node-from-point)
-;;         (symex--go-up (- result result2))))
-;;     result))
-
-(defun symex-depth ()
-  "DEPRECATED.  Renamed to `symex-height`.
-
-This interface will be removed in a future version."
-  (symex-height))
+  (symex-save-excursion
+   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+     (length moves))))
 
 (defun symex-next-visual-line (&optional count)
   "Coordinate navigation to move down.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -440,17 +440,20 @@ approach is the one employed here."
                     symex--traversal-postorder-in-tree))
         (height (symex-height))
         (index (symex-index)))
-    (let* ((find-neighboring-branch
+    (let* ((ensure-at-first-node
             (symex-traversal
-             (maneuver (decision (at first)
-                                 symex--move-zero
-                                 symex--traversal-goto-first)
+             (decision (at first)
+                       symex--move-zero
+                       symex--traversal-goto-first)))
+           (find-neighboring-branch
+            (symex-traversal
+             (maneuver ensure-at-first-node
                        (circuit (precaution traverse
                                             (afterwards (not (lambda ()
                                                                (= (symex-height)
                                                                   height))))))
                        traverse
-                       symex--traversal-goto-first)))
+                       ensure-at-first-node)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -469,7 +472,12 @@ approach is the one employed here."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))))))))
+                    (beforehand (not (at root)))
+                    (afterwards (lambda ()
+                                  (and (= (symex-index)
+                                          index)
+                                       (= (symex-height)
+                                          height))))))))))
 
 (defun symex--leap-forward (&optional soar)
   "Leap forward to a neighboring branch, preserving height and position.
@@ -512,7 +520,12 @@ the implementation."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))))))))
+                    (beforehand (not (at root)))
+                    (afterwards (lambda ()
+                                  (and (= (symex-index)
+                                          index)
+                                       (= (symex-height)
+                                          height))))))))))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -353,8 +353,13 @@ Version 2017-11-01"
         result))))
 
 (defun symex--point-height-offset-helper (orig-pos)
-  "Compute the height offset of the current symex from the lowest one indicated by point."
-  (cond ((symex-ts--point-at-root-symex-p)
+  "A helper to compute the height offset of the current symex.
+
+This will always be zero for symex-oriented languages such as Lisp,
+but in languages like Python where the same point position could
+correspond to multiple hierarchy levels, this function computes the
+difference from the lowest such level."
+  (cond ((symex--point-at-root-symex-p)
          (if (= orig-pos (point))
              0
            -1))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -322,14 +322,16 @@ Version 2017-11-01"
 (defun symex-select-nearest ()
   "Select symex nearest to point."
   (interactive)
-  (cond ((and (not (eobp))
-              (save-excursion (forward-char) (lispy-right-p)))  ; |)
-         (forward-char)
-         (lispy-different))
-        ((thing-at-point 'sexp)  ; som|ething
-         (beginning-of-thing 'sexp))
-        (t (symex-if-stuck (symex--go-backward)
-                           (symex--go-forward))))
+  (if tree-sitter-mode
+      (symex-ts-set-current-node-from-point)
+    (cond ((and (not (eobp))
+                (save-excursion (forward-char) (lispy-right-p))) ; |)
+           (forward-char)
+           (lispy-different))
+          ((thing-at-point 'sexp)       ; som|ething
+           (beginning-of-thing 'sexp))
+          (t (symex-if-stuck (symex--go-backward)
+                             (symex--go-forward)))))
   (point))
 
 (defun symex-select-nearest-in-line ()

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -492,15 +492,15 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (maneuver (decision (at first)
-                                 symex--move-zero
-                                 symex--traversal-goto-first)
-                       (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
-                       traverse
-                       symex--traversal-goto-first)))
+             (venture (decision (at first)
+                                symex--move-zero
+                                symex--traversal-goto-first)
+                      (circuit (precaution traverse
+                                           (afterwards (not (lambda ()
+                                                              (= (symex-height)
+                                                                 height))))))
+                      traverse
+                      symex--traversal-goto-first)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -509,16 +509,16 @@ approach is the one employed here."
                                                    index)))))))
            (leap-backward
             (symex-traversal
-             (maneuver find-neighboring-branch
-                       run-along-branch))))
+             (venture find-neighboring-branch
+                      run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver leap-backward
-                              (circuit
-                               (precaution leap-backward
-                                           (beforehand (lambda ()
-                                                         (< (symex-index)
-                                                            index))))))
+        (precaution (venture leap-backward
+                             (circuit
+                              (precaution leap-backward
+                                          (beforehand (lambda ()
+                                                        (< (symex-index)
+                                                           index))))))
                     (beforehand (not (at root)))
                     (afterwards (lambda ()
                                   (and (= (symex-index)
@@ -541,14 +541,14 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (precaution (maneuver (decision (at last)
-                                             symex--move-zero
-                                             symex--traversal-goto-last)
-                                   (circuit (precaution traverse
-                                                        (afterwards (not (lambda ()
-                                                                           (= (symex-height)
-                                                                              height))))))
-                                   traverse)
+             (precaution (venture (decision (at last)
+                                            symex--move-zero
+                                            symex--traversal-goto-last)
+                                  (circuit (precaution traverse
+                                                       (afterwards (not (lambda ()
+                                                                          (= (symex-height)
+                                                                             height))))))
+                                  traverse)
                          (afterwards (lambda ()
                                        (= (symex-height)
                                           height))))))
@@ -560,16 +560,16 @@ the implementation."
                                                    index)))))))
            (leap-forward
             (symex-traversal
-             (maneuver find-neighboring-branch
-                       run-along-branch))))
+             (venture find-neighboring-branch
+                      run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver leap-forward
-                              (circuit
-                               (precaution leap-forward
-                                           (beforehand (lambda ()
-                                                         (< (symex-index)
-                                                            index))))))
+        (precaution (venture leap-forward
+                             (circuit
+                              (precaution leap-forward
+                                          (beforehand (lambda ()
+                                                        (< (symex-index)
+                                                           index))))))
                     (beforehand (not (at root)))
                     (afterwards (lambda ()
                                   (and (= (symex-index)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -324,14 +324,7 @@ Version 2017-11-01"
   (interactive)
   (if tree-sitter-mode
       (symex-ts-set-current-node-from-point)
-    (cond ((and (not (eobp))
-                (save-excursion (forward-char) (lispy-right-p))) ; |)
-           (forward-char)
-           (lispy-different))
-          ((thing-at-point 'sexp)       ; som|ething
-           (beginning-of-thing 'sexp))
-          (t (symex-if-stuck (symex--go-backward)
-                             (symex--go-forward)))))
+    (symex-lisp--select-nearest))
   (point))
 
 (defun symex-select-nearest-in-line ()
@@ -361,9 +354,10 @@ Version 2017-11-01"
 
 (defun symex--point-height-offset-helper (orig-pos)
   "Compute the height offset of the current symex from the lowest one indicated by point."
-  (cond ((symex-ts-at-root-p) (if (= orig-pos (point))
-                                  0
-                                -1))
+  (cond ((symex-ts--point-at-root-symex-p)
+         (if (= orig-pos (point))
+             0
+           -1))
         ((not (= (point) orig-pos)) -1)
         (t (symex--go-down)
            (1+ (symex--point-height-offset-helper orig-pos)))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -541,14 +541,17 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (maneuver (decision (at last)
-                                 symex--move-zero
-                                 symex--traversal-goto-last)
-                       (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
-                       traverse)))
+             (precaution (maneuver (decision (at last)
+                                             symex--move-zero
+                                             symex--traversal-goto-last)
+                                   (circuit (precaution traverse
+                                                        (afterwards (not (lambda ()
+                                                                           (= (symex-height)
+                                                                              height))))))
+                                   traverse)
+                         (afterwards (lambda ()
+                                       (= (symex-height)
+                                          height))))))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -38,8 +38,6 @@
 (require 'symex-interface-common-lisp)
 (require 'symex-interface-arc)
 (require 'symex-interop)
-(require 'tree-sitter)
-(require 'symex-ts)
 
 ;; These are customization or config variables defined elsewhere;
 ;; explicitly indicating them here to avoid byte compile warnings
@@ -648,10 +646,9 @@ ORIG-FN applied to ARGS is the invocation being advised."
   (unless (member evil-next-state '(emacslike normallike))
     ;; these are "internal" state transitions, used in e.g. symex-evaluate
     (deactivate-mark)
-    (when tree-sitter-mode
-      (symex-ts--delete-overlay))
     (when symex-refocus-p
-      (symex--restore-scroll-margin))))
+      (symex--restore-scroll-margin))
+    (symex--primitive-exit)))
 
 (provide 'symex-misc)
 ;;; symex-misc.el ends here

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -349,7 +349,7 @@ Version 2017-11-01"
 (defun symex-index ()  ; TODO: may be better framed as a computation
   "Get relative (from start of containing symex) index of current symex."
   (interactive)
-  (save-excursion
+  (symex-save-excursion
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
             (result 0))
@@ -382,19 +382,21 @@ Like `save-excursion`, but in addition to preserving the point
 position, this also preserves the structural position in the tree, for
 languages where point position doesn't uniquely identify a tree
 location (e.g. non-symex-based languages like Python)."
-  `(let ((offset 0))
-      (when tree-sitter-mode
-        (setq offset (save-excursion
-                       (symex--point-height-offset)))
-        (symex-select-nearest)
-        (symex--go-up offset))
-      (let ((result
-             (save-excursion
-               ,@body)))
-        (when tree-sitter-mode
-          (symex-select-nearest)
-          (symex--go-up offset))
-        result)))
+  (let ((offset (gensym))
+        (result (gensym)))
+    `(let ((,offset 0))
+       (when tree-sitter-mode
+         (setq ,offset (save-excursion
+                         (symex--point-height-offset)))
+         (symex-select-nearest)
+         (symex--go-up ,offset))
+       (let ((,result
+              (save-excursion
+                ,@body)))
+         (when tree-sitter-mode
+           (symex-select-nearest)
+           (symex--go-up ,offset))
+         ,result))))
 
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -350,7 +350,6 @@ Version 2017-11-01"
   "Get relative (from start of containing symex) index of current symex."
   (interactive)
   (save-excursion
-    (symex-select-nearest)
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
             (result 0))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -335,9 +335,11 @@ Version 2017-11-01"
   (symex-save-excursion
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
+            (move-made symex--move-zero)
             (result 0))
-        (while (< current-location original-location)
-          (symex--execute-tree-move (symex-make-move 1 0))
+        (while (and move-made
+                    (< current-location original-location))
+          (setq move-made (symex--execute-tree-move (symex-make-move 1 0)))
           (setq current-location (point))
           (setq result (1+ result)))
         result))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -366,6 +366,23 @@ Version 2017-11-01"
     (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
       (length moves))))
 
+;; (defun symex-height ()  ; TODO: may be better framed as a computation
+;;   "Get height (above root) of current symex."
+;;   (interactive)
+;;   (let ((result (save-excursion
+;;                   (symex-select-nearest)
+;;                   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+;;                     (length moves)))))
+;;     (when tree-sitter-mode
+;;       (symex-ts-set-current-node-from-point)
+;;       (let ((result2 (save-excursion
+;;                        (symex-select-nearest)
+;;                        (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+;;                          (length moves)))))
+;;         (symex-ts-set-current-node-from-point)
+;;         (symex--go-up (- result result2))))
+;;     result))
+
 (defun symex-depth ()
   "DEPRECATED.  Renamed to `symex-height`.
 

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -28,7 +28,7 @@
 
 (require 'lispy)
 (require 'evil)
-(require 'symex-primitives-lisp)
+(require 'symex-primitives)
 (require 'symex-evaluator)
 (require 'symex-traversals)
 (require 'symex-interface-elisp)
@@ -319,14 +319,6 @@ Version 2017-11-01"
   (recenter)
   (evil-window-mru))
 
-(defun symex-select-nearest ()
-  "Select symex nearest to point."
-  (interactive)
-  (if tree-sitter-mode
-      (symex-ts-set-current-node-from-point)
-    (symex-lisp--select-nearest))
-  (point))
-
 (defun symex-select-nearest-in-line ()
   "Select symex nearest to point that's on the current line."
   (interactive)
@@ -351,54 +343,6 @@ Version 2017-11-01"
           (setq current-location (point))
           (setq result (1+ result)))
         result))))
-
-(defun symex--point-height-offset-helper (orig-pos)
-  "A helper to compute the height offset of the current symex.
-
-This will always be zero for symex-oriented languages such as Lisp,
-but in languages like Python where the same point position could
-correspond to multiple hierarchy levels, this function computes the
-difference from the lowest such level."
-  (cond ((symex--point-at-root-symex-p)
-         (if (= orig-pos (point))
-             0
-           -1))
-        ((not (= (point) orig-pos)) -1)
-        (t (symex--go-down)
-           (1+ (symex--point-height-offset-helper orig-pos)))))
-
-(defun symex--point-height-offset (&optional orig-pos)
-  "Compute the height offset of the current symex from the lowest one indicated by point."
-  (if (and tree-sitter-mode (not (symex-ts--at-root-p)))
-      ;; don't attempt to calculate offset at the "real" root
-      ;; since offsets are typically computed while ignoring it
-      ;; i.e. they are wrt. "tree root"
-      (let ((orig-pos (or orig-pos (point))))
-        (symex--point-height-offset-helper orig-pos))
-    0))
-
-(defmacro symex-save-excursion (&rest body)
-  "Execute BODY while preserving position in the tree.
-
-Like `save-excursion`, but in addition to preserving the point
-position, this also preserves the structural position in the tree, for
-languages where point position doesn't uniquely identify a tree
-location (e.g. non-symex-based languages like Python)."
-  (let ((offset (gensym))
-        (result (gensym)))
-    `(let ((,offset 0))
-       (when tree-sitter-mode
-         (setq ,offset (save-excursion
-                         (symex--point-height-offset)))
-         (symex-select-nearest)
-         (symex--go-up ,offset))
-       (let ((,result
-              (save-excursion
-                ,@body)))
-         (when tree-sitter-mode
-           (symex-select-nearest)
-           (symex--go-up ,offset))
-         ,result))))
 
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -492,15 +492,15 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (venture (decision (at first)
-                                symex--move-zero
-                                symex--traversal-goto-first)
-                      (circuit (precaution traverse
-                                           (afterwards (not (lambda ()
-                                                              (= (symex-height)
-                                                                 height))))))
-                      traverse
-                      symex--traversal-goto-first)))
+             (maneuver (decision (at first)
+                                 symex--move-zero
+                                 symex--traversal-goto-first)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse
+                       symex--traversal-goto-first)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -519,12 +519,7 @@ approach is the one employed here."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))
-                    (afterwards (lambda ()
-                                  (and (= (symex-index)
-                                          index)
-                                       (= (symex-height)
-                                          height))))))))))
+                    (beforehand (not (at root)))))))))
 
 (defun symex--leap-forward (&optional soar)
   "Leap forward to a neighboring branch, preserving height and position.
@@ -541,17 +536,14 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (precaution (venture (decision (at last)
-                                            symex--move-zero
-                                            symex--traversal-goto-last)
-                                  (circuit (precaution traverse
-                                                       (afterwards (not (lambda ()
-                                                                          (= (symex-height)
-                                                                             height))))))
-                                  traverse)
-                         (afterwards (lambda ()
-                                       (= (symex-height)
-                                          height))))))
+             (maneuver (decision (at last)
+                                 symex--move-zero
+                                 symex--traversal-goto-last)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -570,12 +562,7 @@ the implementation."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))
-                    (afterwards (lambda ()
-                                  (and (= (symex-index)
-                                          index)
-                                       (= (symex-height)
-                                          height))))))))))
+                    (beforehand (not (at root)))))))))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -85,7 +85,7 @@
         (or (bobp)
             (progn (backward-sexp 1)
                    (not (thing-at-point 'sexp))))
-      (error nil)))))
+      (error nil))))
 
 (defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -77,8 +77,15 @@
 
 (defun symex-lisp--point-at-initial-symex-p ()
   "Check if point is at the first symex in the buffer."
-  (and (symex-lisp--point-at-first-symex-p)
-       (symex-lisp--point-at-root-symex-p)))
+  ;; this is used in the primitive motions, so it cannot
+  ;; be defined in terms of them, as the other predicates
+  ;; above are
+  (save-excursion
+    (condition-case nil
+        (or (bobp)
+            (progn (backward-sexp 1)
+                   (not (thing-at-point 'sexp))))
+      (error nil)))))
 
 (defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."
@@ -317,7 +324,7 @@ of symex mode (use the public `symex-go-forward` instead)."
 (defun symex-lisp--backward-one ()
   "Backward one symex."
   (let ((result 0))
-    (unless (symex--point-at-initial-symex-p)
+    (unless (symex-lisp--point-at-initial-symex-p)
       (condition-case nil
           (progn (backward-sexp 1)
                  (setq result (1+ result)))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -53,7 +53,7 @@
   "Check if point is at a root symex."
   (save-excursion
     (symex-lisp--if-stuck t
-                          (symex-lisp--exit)
+                          (symex-lisp--go-down)
                           nil)))
 
 (defun symex-lisp--point-at-first-symex-p ()
@@ -251,8 +251,8 @@ as special cases here."
          (lispy-different))
         ((thing-at-point 'sexp)       ; som|ething
          (beginning-of-thing 'sexp))
-        (t (symex-lisp--if-stuck (symex--go-backward)
-                                 (symex--go-forward)))))
+        (t (symex-lisp--if-stuck (symex-lisp--backward)
+                                 (symex-lisp--forward)))))
 
 (defun symex--get-end-point (count)
   "Get the point value after COUNT symexes.
@@ -355,8 +355,8 @@ of symex mode (use the public `symex-go-backward` instead)."
   (re-search-forward symex--re-symex-line)
   (back-to-indentation))
 
-(defun symex-lisp--enter-one ()
-  "Enter one level."
+(defun symex-lisp--go-up-by-one ()
+  "Go up one level."
   (let ((result 1))
     (cond ((or (symex-empty-list-p)
                (symex--special-empty-list-p))
@@ -380,10 +380,10 @@ of symex mode (use the public `symex-go-backward` instead)."
           (t (setq result 0)))
     result))
 
-(defun symex-lisp--enter (&optional count)
-  "Enter higher symex level.
+(defun symex-lisp--go-up (&optional count)
+  "Go up to a higher level.
 
-Enter COUNT times, defaulting to one.
+Go up COUNT times, defaulting to one.
 
 This is a primitive operation that is provided below the public
 abstraction level of symex.el.  It currently uses built-in Emacs
@@ -394,13 +394,13 @@ of symex mode (use the public `symex-go-up` instead)."
   (let ((count (or count 1))
         (result 0))
     (dotimes (_ count)
-      (let ((res (symex-lisp--enter-one)))
+      (let ((res (symex-lisp--go-up-by-one)))
         (setq result (+ res result))))
     (when (> result 0)
       (symex-make-move 0 result))))
 
-(defun symex-lisp--exit-one ()
-  "Exit one level."
+(defun symex-lisp--go-down-by-one ()
+  "Go down one level."
   (condition-case nil
       (progn (paredit-backward-up 1)
              ;; one-off - better to recognize these as delimiters
@@ -418,10 +418,10 @@ of symex mode (use the public `symex-go-up` instead)."
              1)
     (error 0)))
 
-(defun symex-lisp--exit (&optional count)
-  "Exit to lower symex level.
+(defun symex-lisp--go-down (&optional count)
+  "Go down to a lower level.
 
-Exit COUNT times, defaulting to one.
+Go down COUNT times, defaulting to one.
 
 This is a primitive operation that is provided below the public
 abstraction level of symex.el.  It currently uses built-in Emacs
@@ -432,7 +432,7 @@ of symex mode (use the public `symex-go-down` instead)."
   (let ((count (or count 1))
         (result 0))
     (dotimes (_ count)
-      (let ((res (symex-lisp--exit-one)))
+      (let ((res (symex-lisp--go-down-by-one)))
         (setq result (+ res result))))
     (when (> result 0)
       (symex-make-move 0 (- result)))))
@@ -445,7 +445,7 @@ of symex mode (use the public `symex-go-down` instead)."
 If there is an intervening comment line, then join only up to that
 line."
   (let* ((start (point))
-         (end (save-excursion (symex--go-forward)
+         (end (save-excursion (symex-lisp--forward)
                               (point)))
          (comment-line-position
           (symex--intervening-comment-line-p start end)))
@@ -463,6 +463,16 @@ match."
              (end (save-excursion (re-search-forward pattern)
                                   (match-beginning 0))))
         (delete-region start end))))
+
+;;; Utilities
+
+(defun symex-lisp--exit ()
+  "Take necessary actions upon Symex mode exit.
+
+There are no Lisp-specific actions to take, at the present time, so
+this function does nothing. It is only here for completeness and
+symmetry with the tree-sitter primitives."
+  nil)
 
 
 (provide 'symex-primitives-lisp)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -38,6 +38,18 @@
 ;;; PRIMITIVES ;;;
 ;;;;;;;;;;;;;;;;;;
 
+;;; User Interface
+
+(defun symex-lisp--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  (unless (or (bobp)
+              (symex-lisp--point-at-start-p)
+              (looking-back "," (line-beginning-position))
+              (save-excursion (backward-char)  ; just inside symex
+                              (or (lispy-left-p)
+                                  (symex-string-p))))
+    (backward-sexp)))
+
 ;;; Predicates
 
 (defmacro symex-lisp--if-stuck (do-what operation &rest body)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -44,7 +44,7 @@
   "Helper to adjust point to indicate the correct symex."
   (unless (or (bobp)
               (symex-lisp--point-at-start-p)
-              (looking-back "," (line-beginning-position))
+              (looking-back "[,'`]" (line-beginning-position))
               (save-excursion (backward-char)  ; just inside symex
                               (or (lispy-left-p)
                                   (symex-string-p))))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -150,13 +150,21 @@ difference from the lowest such level."
   "Compute the height offset of the current symex from the lowest one
 indicated by point."
   (if tree-sitter-mode
+      ;; don't attempt to calculate offset at the "real" root
+      ;; since offsets are typically computed while ignoring it
+      ;; i.e. they are wrt. "tree root"
       (cond ((symex-ts--at-root-p) 0)
+            ;; at the "tree root" of the first symex in the buffer,
+            ;; point-height offset must account for "true" root
+            ;; and so it's 1 rather than 0 here
             ((symex-ts--at-initial-p) 1)
-            ;; don't attempt to calculate offset at the "real" root
-            ;; since offsets are typically computed while ignoring it
-            ;; i.e. they are wrt. "tree root"
+            ;; aside from the above special cases, compute point-height
+            ;; offset by just descending as long as point does not change,
+            ;; and counting the number of steps taken
             (t (let* ((orig-pos (point))
                       (offset (symex--point-height-offset-helper orig-pos)))
+                 ;; return to original tree position
+                 ;; before returning the result
                  (goto-char orig-pos)
                  (symex-select-nearest)
                  (symex--go-up offset)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -149,6 +149,9 @@ difference from the lowest such level."
 (defun symex--point-height-offset ()
   "Compute the height offset of the current symex from the lowest one
 indicated by point."
+  ;; TODO: probably make this a tree-sitter utility instead, so that
+  ;; it uses tree-sitter APIs to determine point-height offset instead
+  ;; of doing it at the level of traversals.
   (if tree-sitter-mode
       ;; don't attempt to calculate offset at the "real" root
       ;; since offsets are typically computed while ignoring it

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -33,6 +33,14 @@
 (require 'symex-primitives-lisp)
 (require 'symex-ts)
 
+;;; User Interface
+
+(defun symex--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  (if tree-sitter-mode
+      (symex-ts--adjust-point)
+    (symex-lisp--adjust-point)))
+
 ;;; Predicates
 
 (defun symex--point-at-root-symex-p ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -33,6 +33,50 @@
 (require 'symex-primitives-lisp)
 (require 'symex-ts)
 
+;;; Predicates
+
+(defun symex--point-at-root-symex-p ()
+  "Check if point is at a root symex."
+  (if tree-sitter-mode
+      ;; note that tree-sitter has a global
+      ;; root for the whole file -- that's
+      ;; not the one we mean here, but
+      ;; rather, top level definitions
+      (symex-ts--at-tree-root-p)
+    (symex-lisp--point-at-root-symex-p)))
+
+(defun symex--point-at-first-symex-p ()
+  "Check if point is at the first symex at some level."
+  (if tree-sitter-mode
+      (symex-ts--at-first-p)
+    (symex-lisp--point-at-first-symex-p)))
+
+(defun symex--point-at-last-symex-p ()
+  "Check if point is at the last symex at some level."
+  (if tree-sitter-mode
+      (symex-ts--at-last-p)
+    (symex-lisp--point-at-last-symex-p)))
+
+(defun symex--point-at-final-symex-p ()
+  "Check if point is at the last symex in the buffer."
+  (if tree-sitter-mode
+      (symex-ts--at-final-p)
+    (symex-lisp--point-at-final-symex-p)))
+
+(defun symex--point-at-initial-symex-p ()
+  "Check if point is at the first symex in the buffer."
+  (if tree-sitter-mode
+      (symex-ts--at-initial-p)
+    (symex-lisp--point-at-initial-symex-p)))
+
+(defun symex--point-at-start-p ()
+  "Check if point is at the start of a symex."
+  (if tree-sitter-mode
+      (symex-ts--point-at-start-p)
+    (symex-lisp--point-at-start-p)))
+
+;;; Navigation
+
 (defun symex--forward (&optional count)
   "Forward symex.
 

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -32,6 +32,7 @@
 (require 'evil)
 (require 'evil-surround)
 (require 'evil-cleverparens)  ;; really only need cp-textobjects here
+(require 'symex-primitives)
 (require 'symex-primitives-lisp)
 (require 'symex-utils)
 (require 'symex-traversals)

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -120,15 +120,14 @@ when the way is blocked.")
 
 (symex-deftraversal symex--traversal-climb-branch
   (protocol (move up)
-            (detour (circuit (move forward))
-                    (move up))
-            (circuit (move forward))))
+            (venture (circuit (move forward))
+                     (move up))))
 
 (symex-deftraversal symex--traversal-descend-branch
   (protocol (precaution symex--traversal-goto-first
                         (beforehand (not (at root))))
             (venture (move down)
-                     (precaution (circuit (move backward))
+                     (precaution symex--traversal-goto-first
                                  (beforehand (not (at root)))))))
 
 (defun symex-traverse-forward (count)

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -69,9 +69,8 @@
   "Select highest symex."
   (interactive)
   (symex-execute-traversal (symex-traversal
-                            (venture (move up)
-                                     (circuit (protocol (circuit (move forward))
-                                                        (move up))))))
+                            (circuit (venture (move up)
+                                              (circuit (move forward))))))
   (point))
 
 (symex-deftraversal symex--traversal-preorder

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -69,9 +69,9 @@
   "Select highest symex."
   (interactive)
   (symex-execute-traversal (symex-traversal
-                            (maneuver (move up)
-                                      (circuit (protocol (circuit (move forward))
-                                                         (move up))))))
+                            (venture (move up)
+                                     (circuit (protocol (circuit (move forward))
+                                                        (move up))))))
   (point))
 
 (symex-deftraversal symex--traversal-preorder
@@ -91,16 +91,16 @@
   "Pre-order tree traversal.")
 
 (symex-deftraversal symex--traversal-postorder
-  (protocol (maneuver (move backward)
-                      (circuit (maneuver (move up)
-                                         (circuit (move forward)))))
+  (protocol (venture (move backward)
+                     (circuit (venture (move up)
+                                       (circuit (move forward)))))
             (move down))
   "Post-order tree traversal, continuing to other trees.")
 
 (symex-deftraversal symex--traversal-postorder-in-tree
-  (protocol (precaution (maneuver (move backward)
-                                  (circuit (maneuver (move up)
-                                                     (circuit (move forward)))))
+  (protocol (precaution (venture (move backward)
+                                 (circuit (venture (move up)
+                                                   (circuit (move forward)))))
                         (beforehand (not (at root))))
             (move down))
   "Post-order tree traversal.")
@@ -128,9 +128,9 @@ when the way is blocked.")
 (symex-deftraversal symex--traversal-descend-branch
   (protocol (precaution symex--traversal-goto-first
                         (beforehand (not (at root))))
-            (maneuver (move down)
-                      (precaution (circuit (move backward))
-                                  (beforehand (not (at root)))))))
+            (venture (move down)
+                     (precaution (circuit (move backward))
+                                 (beforehand (not (at root)))))))
 
 (defun symex-traverse-forward (count)
   "Traverse symex as a tree, using pre-order traversal.

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -165,6 +165,12 @@ Automatically set it to the node at point if necessary."
   "Set the current node to the top-most node at point."
   (symex-ts--set-current-node (symex-ts-get-topmost-node-at-point)))
 
+(defun symex-ts-at-root-p ()
+  "Check whether the current node is the root node."
+  (let ((root (tsc-root-node tree-sitter-tree))
+        (cur (symex-ts-get-current-node)))
+    (tsc-node-eq cur root)))
+
 (defun symex-ts-get-topmost-node-at-point ()
   "Return the top-most node at the current point."
   (let ((root (tsc-root-node tree-sitter-tree))

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -258,6 +258,10 @@ Move COUNT times, defaulting to 1."
   (interactive "p")
   (symex-ts--move-with-count #'symex-ts--descend-to-child-with-sibling (symex-make-move 0 1) count))
 
+(defun symex-ts--exit ()
+  "Take necessary tree-sitter related actions upon exiting Symex mode."
+  (symex-ts--delete-overlay))
+
 
 (provide 'symex-ts)
 ;;; symex-ts.el ends here

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -110,16 +110,22 @@ leaf."
           (symex-ts--descend-to-child-with-sibling child))
       nil)))
 
-(defun symex-ts--ascend-to-parent-with-sibling (node)
+(defun symex-ts--ascend-to-parent-with-sibling (node &optional initial)
   "Ascend from NODE to parent recursively.
 
 Recursion will end when the parent node has a sibling or is the
 root."
-  (let ((parent (tsc-get-parent node)))
+  (let ((parent (tsc-get-parent node))
+        (initial (or initial node)))
     (if parent
-        (if (symex-ts--node-has-sibling-p parent)
-            parent
-          (symex-ts--ascend-to-parent-with-sibling parent))
+        ;; visit node if it either has no siblings or changes point,
+        ;; for symmetry with "descend" behavior
+        (cond ((and (not (= (tsc-node-start-position node)
+                            (tsc-node-start-position parent)))
+                    (not (tsc-node-eq node initial)))
+               node)
+              ((symex-ts--node-has-sibling-p parent) parent)
+              (t (symex-ts--ascend-to-parent-with-sibling parent node)))
       node)))
 
 (defun symex-ts--move-with-count (fn move-delta &optional count)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -177,6 +177,12 @@ Automatically set it to the node at point if necessary."
         (p (point)))
     (symex-ts--get-topmost-node (tsc-get-named-descendant-for-position-range root p p))))
 
+;;; User Interface
+
+(defun symex-ts--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  nil)
+
 ;;; Predicates
 
 (defmacro symex-ts--if-stuck (do-what operation &rest body)

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -103,7 +103,7 @@ result."
   "Compute the remaining length of the current symex.
 
 This should be done via DSL computation semantics at some point."
-  (save-excursion
+  (symex-save-excursion
     (let ((result (symex-execute-traversal symex--traversal-goto-last)))
      (1+ (length result)))))
 

--- a/symex.el
+++ b/symex.el
@@ -47,6 +47,7 @@
 (require 'symex-evil)
 (require 'symex-interop)
 (require 'symex-misc)
+(require 'symex-primitives)
 (require 'symex-custom)
 (require 'tree-sitter)
 (require 'symex-ts)

--- a/symex.el
+++ b/symex.el
@@ -116,8 +116,6 @@
   (symex--adjust-point-on-entry)
   (when symex-remember-branch-positions-p
     (symex--clear-branch-memory))
-  (when tree-sitter-mode
-    (symex-ts-set-current-node-from-point))
   (symex-select-nearest)
   (when symex-refocus-p
     ;; smooth scrolling currently not supported


### PR DESCRIPTION
## Description

This fixes the leap branch feature in tree-sitter languages, and also includes other improvements.

For leap branch, there were three main issues:

1. In Lisp, the location of the point/cursor uniquely determines both the height (from root) as well as the index (position along current branch). With tree-sitter languages a point location could correspond to more than one hierarchy level (e.g. in `|date = None`). There are some cases (e.g. when a traversal fails) when we need to return to a particular place in the tree (e.g. the node prior to attempting the traversal). In such cases, it was just using `(goto-char original-position)` and then `(symex-select-nearest)` but this would lose any height information.

2. In Lisp, the "root" node is specific to each tree in the buffer, i.e. each top-level definition. In Tree Sitter there is a notion of a root node for the entire file. In some cases we needed to differentiate these. Mainly, in Symex traversals we only care about checking if we are at a "tree" root and don't really check for "true" root. This has now been fixed so that, for instance, "leap" traversals will check if they encounter "tree root" and will not leave a tree unless you ask it to "soar" (i.e. the same as the behavior in Lisp). At the same time, you can manually descend to "true" root in tree sitter and it preserves branch position as usual.

3. In tree sitter, the nearest selection logic was selecting the outermost expression at point, but motions like going up/down were going all the way to the innermost expression (leaf) where no siblings are encountered. As a result, sometimes, restoring a position after a failed traversal was selecting a node (the "outermost" at point) that would not actually be encountered in manual navigation, since it would ordinarily skip it and go straight to the leaf (the innermost). In these cases (i.e. after a position was restored in this way), attempting to go into an expression like `hello` would fail visually, but actually, it would succeed and claim that the move `(move 0 1)` had been executed. This was fixed by making navigations avoid entering the expression (remaining on the outermost expression) if there are no nodes with siblings all the way down to the leaf, i.e. it just avoids going in if there is nothing interesting in there.

## Summary of changes

I've organized these in terms of the "layers" the changes pertain to, for clarity:

- DSL
	- Rename the existing "maneuver" to "venture" to reflect that it accepts partial completion of the itinerary ("venture to move forward and then up" will accept partial completion but not outright failure)
	- Introduce a new "maneuver" which is all-or-nothing ("move forward and then up" must completely succeed, or it fails)
	- Differentiate failed move (return `nil`) from intentional zero move (return zero move)
	- Improve the evaluator implementation so that the structural recursion is explicit instead of hidden (e.g. maneuvers are decomposed in a car-cdr manner as part of execution and this is now more clear)
	- Improve the elementary interface for the data types used in the language (maneuvers, circuits, etc.)
- Primitives abstraction layer
	- Flesh out the primitives abstraction boundary by implementing predicates for tree-sitter corresponding to those used in Lisp in traversals (e.g. (at root) (at initial) etc.)
	- Be strict about leveraging the lisp and tree-sitter primitives exclusively through the primitives layer and not directly
	- Make the interface of the primitives layer more clear
	- Add a tree-sitter aware "save excursion" macro and use it in place of `save-excursion` where we need to
	- On failed traversals, restore initial position correctly for both lisp and tree-sitter
- Tree-sitter
	- Add a utility to compute point-height offset which is used in e.g. symex-save-excursion and other places to restore the correct height where point alone cannot tell us this
	- "Tree" root vs "true" root
		- Say that five times fast!
		- Add predicates to differentiate these and use them at the appropriate times
	- Make nearest selection and motions mutually consistent wrt selecting the outermost expression
		- Don't descend to leaf if there are no nodes with siblings in the expression
		- But descend if it changes the point position, even if there are no siblings
- Misc
	- Add basic moves as traversals for convenience
	- Make height calculation (symex-height) work correctly with lisp and tree-sitter
	- Make index calculation (symex-index) work correctly with lisp and tree-sitter
	- Fix some cases where an infinite loop was being encountered (e.g. at "true" root)
	- Declare Emacs indent levels in macros so they are properly indented


### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
