### PR TITLE
common-lisp: add sly backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,32 @@ By default, ``C-'`` and ``C-,`` cycle through standard quoting and unquoting pre
    (symex-quote-prefix-list (list "'" "`" "#'" "#`"))
    (symex-unquote-prefix-list (list "," ",@" "#,@"))
 
+Lisp Flavors
+------------
+Symex supports the following lisps:
+
+.. list-table::
+
+   * - Racket
+     - Repl interaction and docs through `racket-mode`.
+
+   * - EmacsLisp
+
+   * - Clojure
+
+   * - Common Lisp
+     - Support for Slime or Sly through `symex-common-lisp-backend`. This
+       defaults to Slime, set to `'sly` to use Sly for Symex repl interaction
+       and doc lookup. For example:
+       ::
+          (use-package symex
+            :config
+            (symex-initialize)
+            (global-set-key (kbd "s-;") 'symex-mode-interface))  ; or whatever keybinding you like
+            (setq symex-common-lisp-backend 'sly)
+
+   * - Arc
+
 Tips
 ====
 

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -60,6 +60,10 @@
   :type 'list
   :group 'symex)
 
+(defcustom symex-common-lisp-backend 'slime
+  "Backend provider for Common Lisp interactive features; defaults to SLIME."
+  :type 'symbol
+  :group 'symex)
 
 (provide 'symex-custom)
 ;;; symex-custom.el ends here

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -61,7 +61,10 @@
   :group 'symex)
 
 (defcustom symex-common-lisp-backend 'slime
-  "Backend provider for Common Lisp interactive features; defaults to SLIME."
+  "Backend provider for Common Lisp interactive features. One of:
+
+  - SLIME: The Superior Lisp Interaction Mode for Emacs.
+  - SLY: Sylvestors Common Lisp IDE for Emacs. A fork of SLIME."
   :type 'symbol
   :group 'symex)
 

--- a/symex-interface-common-lisp.el
+++ b/symex-interface-common-lisp.el
@@ -25,26 +25,42 @@
 
 ;;; Code:
 
-(require 'slime nil 'noerror)
+(require 'slime      nil 'noerror)
 (require 'slime-repl nil 'noerror)
+(require 'sly        nil 'noerror)
+(require 'sly-repl   nil 'noerror)
 (require 'symex-interop)
+(require 'symex-custom)
 
+;; Make the bytecompiler aware of slime
 (declare-function slime-eval-last-expression "ext:slime")
-(declare-function slime-eval-defun "ext:slime")
-(declare-function slime-eval-buffer "ext:slime")
-(declare-function slime-repl "ext:slime-repl")
+(declare-function slime-eval-defun           "ext:slime")
+(declare-function slime-eval-buffer          "ext:slime")
+(declare-function slime-repl                 "ext:slime-repl")
 (declare-function slime-eval-print-last-expression "ext:slime")
-(declare-function slime-documentation "ext:slime")
+(declare-function slime-documentation        "ext:slime")
+
+;; Make the bytecompiler aware of sly
+(declare-function sly-eval-last-expression "ext:sly")
+(declare-function sly-eval-defun           "ext:sly")
+(declare-function sly-eval-buffer          "ext:sly")
+(declare-function sly-repl                 "ext:sly-repl")
+(declare-function sly-eval-print-last-expression "ext:sly")
+(declare-function sly-documentation        "ext:sly")
 
 (defun symex-eval-common-lisp ()
   "Eval last sexp.
 
 Accounts for different point location in evil vs Emacs mode."
   (interactive)
+  (when (eq symex-common-lisp-backend 'sly)
+    (sly-eval-last-expression))
   (slime-eval-last-expression))
 
 (defun symex-eval-definition-common-lisp ()
   "Eval entire containing definition."
+  (when (eq symex-common-lisp-backend 'sly)
+    (sly-eval-defun))
   (slime-eval-defun))
 
 (defun symex-eval-pretty-common-lisp ()
@@ -61,22 +77,32 @@ Accounts for different point location in evil vs Emacs mode."
 (defun symex-eval-print-common-lisp ()
   "Eval symex and print result in buffer."
   (interactive)
-  (call-interactively #'slime-eval-print-last-expression))
+  (call-interactively
+   (if (eq symex-common-lisp-backend 'sly)
+       #'sly-eval-print-last-expression
+       #'slime-eval-print-last-expression)))
 
 (defun symex-describe-symbol-common-lisp ()
   "Describe symbol at point."
   (interactive)
-  (call-interactively #'slime-documentation))
+  (call-interactively
+   (if (eq symex-common-lisp-backend 'sly)
+       #'sly-documentation
+       #'slime-documentation)))
 
 (defun symex-repl-common-lisp ()
   "Go to REPL."
   ;; this already goes to the active repl prompt
   ;; so there's no need to move point there
-  (slime-repl)
+  (if (eq symex-common-lisp-backend 'sly)
+      (sly-repl)
+      (slime-repl))
   (symex-enter-lowest))
 
 (defun symex-run-common-lisp ()
   "Evaluate buffer."
+  (when (eq symex-common-lisp-backend 'sly)
+    (sly-eval-buffer))
   (slime-eval-buffer))
 
 


### PR DESCRIPTION
### Summary of Changes
Closes out #43. The only public facing changes are the addition of `symex-common-lisp-backend`. This defaults to `slime` but users can optionally set it to `sly`.

I tried to do some fancy things to reduce code duplication and the nested checks on this variable, but it didn't fit the project style. I don't think it will be a problem since these runtime checks should be `jit`d away.

I didn't see a place in the docs that says `symex supports the following lisps: ...` so I was unsure where to state:
```
Symex can use Sly as a backend for Common Lisp as opposed to Slime. To do so set symex-common-lisp-backend, 
for example you might have the following use-package call (for Doom emacs):

(use-package! symex
  :config
  (symex-initialize)
  (setq symex-common-lisp-backend 'sly)

  (map! :after evil
        :map evil-motion-state-map
        "\\" #'symex-mode-interface)

  :custom
  (symex-modal-backend 'evil))
```


### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
