### PR TITLE
Handle more special list forms

### DIFF
--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -201,9 +201,9 @@ as special cases here."
 (defun symex--special-empty-list-p ()
   "Check if we're looking at a 'special' empty list."
   (or (save-excursion
-        (symex--racket-splicing-unsyntax-p)
-        (progn (forward-char 5)
-               (lispy-right-p)))
+        (and (symex--racket-splicing-unsyntax-p)
+             (progn (forward-char 5)
+                    (lispy-right-p))))
       (save-excursion
         (and (or (symex--racket-syntax-object-p)
                  (symex--racket-unquote-syntax-p)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -207,6 +207,7 @@ as special cases here."
                     (lispy-right-p))))
       (save-excursion
         (and (or (symex--quoted-list-p)
+                 (symex--unquoted-list-p)
                  (symex--clojure-deref-reader-macro-p)
                  (symex--clojure-literal-lambda-p))
              (progn (forward-char 3)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -391,7 +391,7 @@ of symex mode (use the public `symex-go-up` instead)."
              ;; at the AST level
              (cond ((looking-back "#['`,]" (line-beginning-position))
                     (backward-char 2))
-                   ((looking-back "[#'`]" (line-beginning-position))
+                   ((looking-back "[#'`,]" (line-beginning-position))
                     (backward-char))
                    ((looking-back "@" (line-beginning-position))
                     (backward-char)))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -352,7 +352,9 @@ of symex mode (use the public `symex-go-backward` instead)."
           ((or (and (symex--racket-syntax-object-p)
                     (not (symex--special-empty-list-p)))
                (symex--splicing-unquote-p)
-               (symex--racket-unquote-syntax-p))
+               ;; TODO: exclude special empty first
+               (and (symex--racket-unquote-syntax-p)
+                    (not (symex--special-empty-list-p))))
            (forward-char 3))
           ((symex--racket-splicing-unsyntax-p)
            (forward-char 4))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -201,8 +201,13 @@ as special cases here."
 (defun symex--special-empty-list-p ()
   "Check if we're looking at a 'special' empty list."
   (or (save-excursion
+        (symex--racket-splicing-unsyntax-p)
+        (progn (forward-char 5)
+               (lispy-right-p)))
+      (save-excursion
         (and (or (symex--racket-syntax-object-p)
-                 (symex--racket-unquote-syntax-p))
+                 (symex--racket-unquote-syntax-p)
+                 (symex--splicing-unquote-p))
              (progn (forward-char 4)
                     (lispy-right-p))))
       (save-excursion
@@ -393,6 +398,10 @@ of symex mode (use the public `symex-go-up` instead)."
                     (backward-char 2))
                    ((looking-back "[#'`,]" (line-beginning-position))
                     (backward-char))
+                   ((looking-back "#,@" (line-beginning-position))
+                    (backward-char 3))
+                   ((looking-back ",@" (line-beginning-position))
+                    (backward-char 2))
                    ((looking-back "@" (line-beginning-position))
                     (backward-char)))
              1)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -342,27 +342,24 @@ of symex mode (use the public `symex-go-backward` instead)."
 (defun symex--enter-one ()
   "Enter one level."
   (let ((result 1))
-    (cond ((and (lispy-left-p)
-                (not (symex-empty-list-p)))
-           (forward-char))
+    (cond ((or (symex-empty-list-p)
+               (symex--special-empty-list-p))
+           (setq result 0))
+          ((lispy-left-p) (forward-char))
           ;; note that at least some symex features would benefit by
           ;; treating these special cases as "symex-left-p" but it
           ;; would likely be too much special case handling to be
           ;; worth it to support those cases naively, without an AST
-          ((or (and (symex--racket-syntax-object-p)
-                    (not (symex--special-empty-list-p)))
+          ((or (symex--racket-syntax-object-p)
                (symex--splicing-unquote-p)
-               ;; TODO: exclude special empty first
-               (and (symex--racket-unquote-syntax-p)
-                    (not (symex--special-empty-list-p))))
+               (symex--racket-unquote-syntax-p))
            (forward-char 3))
           ((symex--racket-splicing-unsyntax-p)
            (forward-char 4))
-          ((and (or (symex--quoted-list-p)
-                    (symex--unquoted-list-p)
-                    (symex--clojure-deref-reader-macro-p)
-                    (symex--clojure-literal-lambda-p))
-                (not (symex--special-empty-list-p)))
+          ((or (symex--quoted-list-p)
+               (symex--unquoted-list-p)
+               (symex--clojure-deref-reader-macro-p)
+               (symex--clojure-literal-lambda-p))
            (forward-char 2))
           (t (setq result 0)))
     result))


### PR DESCRIPTION
### Summary of Changes

Handle more special cases of list forms for movement/navigation. Tested on:

```
()
(+ 2 3)
'(+ 2 3)
'()
#'(+ 2 3)
#'()
`(+ 2 3)
`()
#`(+ 2 3)
#`()
#(1 2 3)
#()
,(+ 2 3)
,()
#,(+ 2 3)
#,()
,@(+ 2 3)
#,@(+ 2 3)
#,@()
,@()
@(1 2 3)
@()
```

One thing to give more thought to down the line is that the primitive Lisp APIs (e.g. Emacs, paredit) don't consider the above to be symexes. That's why they need to be handled as special cases. But doing it on a one-off basis means that only motions/navigations handle them correctly, and for instance transformations like emit and capture don't, and there is no unity in the handling of these cases.

A better way to do it might be to extend the primitives layer to recognize these forms properly, and rewrite the primitive transformations (e.g. emit and capture) by leveraging the Symex DSL so that it uses the definition of symex encoded in the primitive layer, rather than multiple independent definitions (e.g. Emacs vs Paredit, etc.) that don't really agree.

Also, since these are small and well-bounded cases, it might be good to start writing tests for Symex by writing tests for these (not included in this PR).

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
