### PR TITLE
Handle an edge case where going down to root would hang

### DIFF
--- a/symex-ts.el
+++ b/symex-ts.el
@@ -214,7 +214,7 @@ Automatically set it to the node at point if necessary."
 Note that this does not consider global root to be a tree root."
   (let ((root (tsc-root-node tree-sitter-tree))
         (cur (symex-ts-get-current-node)))
-    (let ((parent (tsc-get-parent cur)))
+    (let ((parent (symex-ts--ascend-to-parent-with-sibling cur)))
       (and parent (tsc-node-eq parent root)))))
 
 (defun symex-ts--at-first-p ()

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -214,8 +214,8 @@ Automatically set it to the node at point if necessary."
 Note that this does not consider global root to be a tree root."
   (let ((root (tsc-root-node tree-sitter-tree))
         (cur (symex-ts-get-current-node)))
-    (let ((parent (symex-ts--ascend-to-parent-with-sibling cur)))
-      (and parent (tsc-node-eq parent root)))))
+    (let ((parent (tsc-get-parent cur)))
+      (or (not parent) (tsc-node-eq parent root)))))
 
 (defun symex-ts--at-first-p ()
   "Check if the current node is the first one at some level."


### PR DESCRIPTION
### Summary of Changes

In a javascript file like this one:

```
window.BENCHMARK_DATA = {
  "lastUpdate": 1658432364487,
  "repoUrl": "https://github.com/countvajhula/qi",
}
```
([link to actual file](https://github.com/countvajhula/qi/blob/gh-pages/benchmarks/data.js))

... going "up" towards root while one level below it was causing it to hang.

The reason seems to be that there is a parent node without siblings encountered before the root and that was breaking an assumption somewhere. This PR changes the `symex-ts--at-tree-root-p` check to be consistent with the check for siblings used in actual movements, to fix the issue.

(**Note**: There is another issue in the same file where going down from root to a child node seems to skip a level in some cases. I plan to investigate that further but if I don't get to it soon I might do it as a follow-up PR.)

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
