### PR TITLE
Generalize overlay for use in Lisp too

### DIFF
--- a/symex-misc.el
+++ b/symex-misc.el
@@ -530,6 +530,10 @@ the implementation."
                                        (= (symex-height)
                                           height))))))))))
 
+(defun symex-select-nearest-advice (&rest _)
+  "Advice to select the nearest symex."
+  (symex-select-nearest))
+
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."
   (interactive)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -38,6 +38,7 @@
 (require 'symex-interface-common-lisp)
 (require 'symex-interface-arc)
 (require 'symex-interop)
+(require 'symex-ui)
 
 ;; These are customization or config variables defined elsewhere;
 ;; explicitly indicating them here to avoid byte compile warnings
@@ -533,7 +534,7 @@ the implementation."
   "Things to do as part of symex selection, e.g. after navigations."
   (interactive)
   (when symex-highlight-p
-    (mark-sexp)))
+    (symex--update-overlay)))
 
 (defun symex-selection-advice (orig-fn &rest args)
   "Attach symex selection side effects to a given function.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -532,7 +532,8 @@ the implementation."
 
 (defun symex-select-nearest-advice (&rest _)
   "Advice to select the nearest symex."
-  (symex-select-nearest))
+  (when (evil-symex-state-p)
+    (symex-select-nearest)))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -266,18 +266,34 @@ as special cases here."
         (t (symex-lisp--if-stuck (symex-lisp--backward)
                                  (symex-lisp--forward)))))
 
-(defun symex--get-end-point (count)
+(defun symex-lisp--get-starting-point ()
+  "Get the point value at the start of the current symex."
+  (save-excursion
+    (unless (symex--point-at-start-p)
+      (backward-sexp))
+    (point)))
+
+(defun symex-lisp--get-end-point-helper (count)
+  "Helper to get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found.
+
+Note that this mutates point - it should not be called directly."
+  (if (= count 0)
+      (point)
+    (condition-case nil
+        (forward-sexp)
+      (error (point)))
+    (symex-lisp--get-end-point-helper (1- count))))
+
+(defun symex-lisp--get-end-point (count)
   "Get the point value after COUNT symexes.
 
 If the containing expression terminates earlier than COUNT
 symexes, returns the end point of the last one found."
   (save-excursion
-    (if (= count 0)
-        (point)
-      (condition-case nil
-          (forward-sexp)
-        (error (point)))
-      (symex--get-end-point (1- count)))))
+    (symex-lisp--get-end-point-helper count)))
 
 (defun symex-lisp--forward-one ()
   "Forward one symex."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -295,6 +295,13 @@ symexes, returns the end point of the last one found."
   (save-excursion
     (symex-lisp--get-end-point-helper count)))
 
+(defun symex-lisp--point-height-offset ()
+  "Compute the height offset of the current symex from the lowest one
+indicated by point.
+
+For symex-oriented languages like Lisp, this is always zero."
+  0)
+
 (defun symex-lisp--forward-one ()
   "Forward one symex."
   (let ((original-location (point))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -270,7 +270,9 @@ as special cases here."
   "Get the point value at the start of the current symex."
   (save-excursion
     (unless (symex--point-at-start-p)
-      (backward-sexp))
+      (condition-case nil
+          (backward-sexp)
+        (error nil)))
     (point)))
 
 (defun symex-lisp--get-end-point-helper (count)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -199,6 +199,21 @@ location (e.g. non-symex-based languages like Python)."
          (symex--go-up ,offset)
          ,result))))
 
+(defun symex--get-starting-point ()
+  "Get the point value at the start of the current symex."
+  (if tree-sitter-mode
+      (symex-ts--get-starting-point)
+    (symex-lisp--get-starting-point)))
+
+(defun symex--get-end-point (count)
+  "Get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found."
+  (if tree-sitter-mode
+      (symex-ts--get-end-point count)
+    (symex-lisp--get-end-point count)))
+
 (defun symex-select-nearest ()
   "Select symex nearest to point."
   (interactive)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -225,6 +225,7 @@ symexes, returns the end point of the last one found."
 (defun symex--primitive-exit ()
   "Take any necessary actions as part of exiting Symex mode, at a
 primitive level."
+  (symex--delete-overlay)
   (if tree-sitter-mode
       (symex-ts--exit)
     (symex-lisp--exit)))

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -42,8 +42,16 @@
 
 (defvar symex-ts--current-node nil "The current Tree Sitter node.")
 
-(defvar symex-ts--current-overlay nil "The current overlay which highlights the current node.")
+(defun symex-ts--get-starting-point ()
+  "Get the point value at the start of the current symex."
+  (tsc-node-start-position symex-ts--current-node))
 
+(defun symex-ts--get-end-point (count)
+  "Get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found."
+  (tsc-node-end-position symex-ts--current-node))
 
 (defun symex-ts--delete-overlay ()
   "Delete the highlight overlay."

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -68,8 +68,7 @@ symexes, returns the end point of the last one found."
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)
-  (goto-char (tsc-node-start-position node))
-  (symex-ts--update-overlay symex-ts--current-node))
+  (goto-char (tsc-node-start-position node)))
 
 (defun symex-ts--get-topmost-node (node)
   "Return the highest node in the tree starting from NODE.
@@ -163,11 +162,6 @@ Return a Symex move (list with x,y node offsets tagged with
     ;; Return the Symex move that was executed, or nil to signify that
     ;; the movement failed
     (when (not (symex--are-moves-equal-p move symex--move-zero)) move)))
-
-(defun symex-ts--after-tree-modification ()
-  "Handle any tree modification."
-  (symex-ts--delete-overlay)
-  (setq-local symex-ts--current-node nil))
 
 (defun symex-ts-current-node-sexp ()
   "Print the current node as an s-expression."
@@ -288,7 +282,7 @@ Move COUNT times, defaulting to 1."
 
 (defun symex-ts--exit ()
   "Take necessary tree-sitter related actions upon exiting Symex mode."
-  (symex-ts--delete-overlay))
+  (setq-local symex-ts--current-node nil))
 
 
 (provide 'symex-ts)

--- a/symex-ui.el
+++ b/symex-ui.el
@@ -28,12 +28,38 @@
 
 (require 'symex-custom)
 
+(defface symex--current-node-face
+  '((t :inherit highlight :extend nil))
+  "Face used to highlight the current tree node."
+  :group 'symex-faces)
+
+(defvar symex--current-overlay nil "The current overlay which highlights the current node.")
+
+(defun symex--delete-overlay ()
+  "Delete the highlight overlay."
+  (when symex--current-overlay
+    (delete-overlay symex--current-overlay)))
+
+(defun symex--update-overlay ()
+  "Update the highlight overlay to match the start/end position of NODE."
+  (when symex--current-overlay
+    (delete-overlay symex--current-overlay))
+  (setq-local symex--current-overlay
+              (make-overlay (symex--get-starting-point)
+                            (symex--get-end-point 1)))
+  (overlay-put symex--current-overlay 'face 'symex--current-node-face))
+
+(defun symex--overlay-active-p ()
+  "Is the overlay active?"
+  (and symex--current-overlay
+       (overlay-start symex--current-overlay)))
+
 (defun symex--toggle-highlight ()
   "Toggle highlighting of selected symex."
   (interactive)
-  (if mark-active
-      (deactivate-mark)
-    (mark-sexp))
+  (if (symex--overlay-active-p)
+      (symex--delete-overlay)
+    (symex--update-overlay))
   (setq symex-highlight-p
         (not symex-highlight-p)))
 

--- a/symex.el
+++ b/symex.el
@@ -160,6 +160,8 @@ advises functions to enable or disable features based on user configuration."
     (advice-add #'symex-go-up :around #'symex--return-to-branch-position)
     (advice-add #'symex-go-backward :around #'symex--forget-branch-positions)
     (advice-add #'symex-go-forward :around #'symex--forget-branch-positions))
+  (advice-add #'undo-tree-undo :after #'symex-select-nearest-advice)
+  (advice-add #'undo-tree-redo :after #'symex-select-nearest-advice)
   (symex--add-selection-advice)
   ;; initialize modal interface frontend
   (cond ((eq symex-modal-backend 'hydra)
@@ -186,6 +188,8 @@ configuration to be disabled and the new one adopted."
   (advice-remove #'symex-go-up #'symex--return-to-branch-position)
   (advice-remove #'symex-go-backward #'symex--forget-branch-positions)
   (advice-remove #'symex-go-forward #'symex--forget-branch-positions)
+  (advice-remove #'undo-tree-undo #'symex-select-nearest-advice)
+  (advice-remove #'undo-tree-redo #'symex-select-nearest-advice)
   (symex--remove-selection-advice))
 
 ;;;###autoload


### PR DESCRIPTION
### Summary of Changes

The Symex master branch contains an optional "highlight" feature that uses Emacs regions to highlight the current expression. This is not a great way to do it since regions have existing connotations that interfere with their ability to play the pure UI role of highlighting. For instance, Evil considers an active region to mean "Visual mode". Thus, using highlighting causes existing features like `e`valuate to work in unexpected ways.

The tree-sitter branch introduces an overlay for highlighting the currently selected expression. This is the right way to do it and it doesn't suffer from the problems associated with using regions. The present PR promotes the overlay used for tree-sitter code to the UI level (instead of the primitive tree-sitter level) so that it works for both tree-sitter as well as Lisp, with appropriate primitives fulfilling basic utilities in Lisp and tree-sitter.

(Moved from polaris64/symex.el#1)

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
