### PR TITLE
Move ts-specific overlay to dev module for use in the hydra

### DIFF
--- a/dev/dev-utils.el
+++ b/dev/dev-utils.el
@@ -17,18 +17,61 @@
 ;; Symex-TS hydra: useful for debugging Tree Sitter movements outside
 ;; of the rest of Symex.
 
+(defface symex-ts-current-node-face
+  '((t :inherit highlight :extend nil))
+  "Face used to highlight the current tree node."
+  :group 'symex-faces)
+
+(defvar symex-ts--current-overlay nil "The current overlay which highlights the current node.")
+
+(defun symex-ts--delete-overlay ()
+  "Delete the highlight overlay."
+  (when symex-ts--current-overlay
+    (delete-overlay symex-ts--current-overlay)))
+
+(defun symex-ts--update-overlay (node)
+  "Update the highlight overlay to match the start/end position of NODE."
+  (when symex-ts--current-overlay
+    (delete-overlay symex-ts--current-overlay))
+  (setq-local symex-ts--current-overlay (make-overlay (tsc-node-start-position node) (tsc-node-end-position node)))
+  (overlay-put symex-ts--current-overlay 'face 'symex-ts-current-node-face))
+
 (defun symex-ts--hydra-exit ()
   "Handle Hydra exit."
   (symex-ts--delete-overlay))
+
+(defun symex-ts--move-next ()
+  "Move to next sibling."
+  (interactive)
+  (symex-ts-move-next-sibling)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-previous ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-prev-sibling)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-parent ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-parent)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-child ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-child)
+  (symex-ts--update-overlay symex-ts--current-node))
 
 (defhydra hydra-symex-ts (:post (symex-ts--hydra-exit))
   "Symex-TS."
   ("d" symex-ts-current-node-sexp "DEBUG NODE")
 
-  ("h" symex-ts-move-prev-sibling "prev")
-  ("l" symex-ts-move-next-sibling "next")
-  ("j" symex-ts-move-parent "parent")
-  ("k" symex-ts-move-child "child"))
+  ("h" symex-ts--move-previous "prev")
+  ("l" symex-ts--move-next "next")
+  ("j" symex-ts--move-parent "parent")
+  ("k" symex-ts--move-child "child"))
 
 (defun symex-ts-launch ()
   "Start the Symex-TS hydra."
@@ -36,6 +79,7 @@
 
   ;; Set the current node to the top-most node at point
   (symex-ts-set-current-node-from-point)
+  (symex-ts--update-overlay symex-ts--current-node)
 
   ;; Launch hydra
   (hydra-symex-ts/body))

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -36,6 +36,8 @@
 (require 'symex-utils-ts)
 
 
+(defvar-local symex-ts--current-node nil "The current Tree Sitter node.")
+
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -36,30 +36,6 @@
 (require 'symex-utils-ts)
 
 
-(defface symex-ts-current-node-face
-  '((t :inherit highlight :extend nil))
-  "Face used to highlight the current tree node."
-  :group 'symex-faces)
-
-
-(defvar symex-ts--current-node nil "The current Tree Sitter node.")
-
-(defun symex-ts--delete-overlay ()
-  "Delete the highlight overlay."
-  (when symex-ts--current-overlay
-    (delete-overlay symex-ts--current-overlay)))
-
-(defun symex-ts--update-overlay (node)
-  "Update the highlight overlay to match the start/end position of NODE."
-  (when symex-ts--current-overlay
-    (delete-overlay symex-ts--current-overlay))
-  (setq-local symex-ts--current-overlay (make-overlay (tsc-node-start-position node) (tsc-node-end-position node)))
-  (overlay-put symex-ts--current-overlay 'face 'symex-ts-current-node-face))
-
-(defun symex-ts--exit ()
-  "Take necessary tree-sitter related actions upon exiting Symex mode."
-  (symex-ts--delete-overlay))
-
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)


### PR DESCRIPTION
### Summary of Changes

There was still some leftover overlay code in the ts module which was being used by the hydra used for development. I've moved that over to the dev module.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
