### PR TITLE
Soar across trees

### DIFF
--- a/symex-misc.el
+++ b/symex-misc.el
@@ -412,6 +412,12 @@ Leaps COUNT times, defaulting to once."
   (dotimes (_ count)
     (symex--leap-forward)))
 
+(defun symex--tree-index ()
+  "Index of current tree."
+  (symex-save-excursion
+   (symex-goto-lowest)
+   (symex-index)))
+
 (defun symex--leap-backward (&optional soar)
   "Leap backward to a neighboring branch, preserving height and position.
 
@@ -442,7 +448,8 @@ approach is the one employed here."
                       symex--traversal-postorder
                     symex--traversal-postorder-in-tree))
         (height (symex-height))
-        (index (symex-index)))
+        (index (symex-index))
+        (original-tree-index (symex--tree-index)))
     (let* ((ensure-at-first-node
             (symex-traversal
              (decision (at first)
@@ -452,9 +459,13 @@ approach is the one employed here."
             (symex-traversal
              (maneuver ensure-at-first-node
                        (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
+                                            (afterwards (lambda ()
+                                                          (or (not (= (symex-height)
+                                                                      height))
+                                                              (if soar
+                                                                  (= original-tree-index
+                                                                     (symex--tree-index))
+                                                                nil))))))
                        traverse
                        ensure-at-first-node)))
            (run-along-branch
@@ -494,16 +505,21 @@ the implementation."
                       symex--traversal-preorder
                     symex--traversal-preorder-in-tree))
         (height (symex-height))
-        (index (symex-index)))
+        (index (symex-index))
+        (original-tree-index (symex--tree-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
              (maneuver (decision (at last)
                                  symex--move-zero
                                  symex--traversal-goto-last)
                        (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
+                                            (afterwards (lambda ()
+                                                          (or (not (= (symex-height)
+                                                                      height))
+                                                              (if soar
+                                                                  (= original-tree-index
+                                                                     (symex--tree-index))
+                                                                nil))))))
                        traverse)))
            (run-along-branch
             (symex-traversal

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -44,7 +44,9 @@
   "Go to last symex on the present branch.")
 
 (symex-deftraversal symex--traversal-goto-lowest
-  (circuit (move down))
+  (circuit
+   (precaution (move down)
+               (beforehand (not (at root)))))
   "Go to lowest (root) symex in present tree.")
 
 (defun symex-goto-first ()


### PR DESCRIPTION
### Summary of Changes

There are often times when we want to jump to the neighboring tree. The current way to do that is to keep leaping/soaring until you reach the next tree. This PR makes "soar" specifically jump to the neighboring tree and not stay within the current tree.

More detail: currently, leap and soar are identical except that leap won't cross to other trees, while soar will. This was done mainly because in some cases if you "leap" you may find yourself in a totally different part of the code (in another tree) and that's usually not what you want. So "leap" encodes the common expectation that you want to stay in the current tree. "Soar" allows you to explicitly say that you're willing to go to another tree.

But this distinction between leap and soar is perhaps too subtle, and so soar isn't as useful as it could be. This PR makes the distinction sharper so that leap is explicitly "within tree" and soar is explicitly "across trees."

In a future PR I think it would be nice to make soar even more different, where it could leverage the exact coordinate information from the current tree and attempt to return to the same coordinates in the neighboring tree. This would allow us to go between neighboring trees to the exact analogous location in the other tree, if the trees happen to be very similar (as they often are).

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
