### PR TITLE
Support universal arg for debugging in clojure and elisp

### DIFF
--- a/symex-interface-clojure.el
+++ b/symex-interface-clojure.el
@@ -42,9 +42,9 @@ Accounts for different point location in evil vs Emacs mode."
   (interactive)
   (cider-eval-last-sexp))
 
-(defun symex-eval-definition-clojure ()
+(defun symex-eval-definition-clojure (debug-it)
   "Eval entire containing definition."
-  (cider-eval-defun-at-point nil))
+  (cider-eval-defun-at-point debug-it))
 
 (defun symex-eval-pretty-clojure ()
   "Evaluate symex and render the result in a useful string form."

--- a/symex-interface-elisp.el
+++ b/symex-interface-elisp.el
@@ -33,9 +33,9 @@
   (interactive)
   (eval-last-sexp nil))
 
-(defun symex-eval-definition-elisp ()
+(defun symex-eval-definition-elisp (debug-it)
   "Eval entire containing definition."
-  (eval-defun nil))
+  (eval-defun debug-it))
 
 (defun symex-eval-pretty-elisp ()
   "Evaluate symex and render the result in a useful string form."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -142,17 +142,17 @@ to how the Lisp interpreter does it (when it is following
     (symex--do-while-traversing #'symex--evaluate
                                 (symex-make-move 1 0))))
 
-(defun symex-evaluate-definition ()
+(defun symex-evaluate-definition (&optional debug-it)
   "Evaluate entire containing symex definition."
-  (interactive)
+  (interactive "P")
   (cond ((member major-mode symex-racket-modes)
          (symex-eval-definition-racket))
         ((member major-mode symex-elisp-modes)
-         (symex-eval-definition-elisp))
+         (symex-eval-definition-elisp debug-it))
         ((equal major-mode 'scheme-mode)
          (symex-eval-definition-scheme))
         ((member major-mode symex-clojure-modes)
-         (symex-eval-definition-clojure))
+         (symex-eval-definition-clojure debug-it))
         ((equal major-mode 'lisp-mode)
          (symex-eval-definition-common-lisp))
         ((equal major-mode 'arc-mode)


### PR DESCRIPTION
### Summary of Changes

In elisp and clojure, the universal arg evaluates an expression in a debug mode. These are pretty handy and universal arg isn't currently used for these commands in symex. So I've added it here in the hope that we think it's a good idea.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
