### PR TITLE
call cider-pprint-eval-last-sexp to pretty print clojure

### DIFF
--- a/symex-interface-clojure.el
+++ b/symex-interface-clojure.el
@@ -49,7 +49,7 @@ Accounts for different point location in evil vs Emacs mode."
 (defun symex-eval-pretty-clojure ()
   "Evaluate symex and render the result in a useful string form."
   (interactive)
-  (symex-eval-clojure))
+  (cider-pprint-eval-last-sexp))
 
 (defun symex-eval-thunk-clojure ()
   "Evaluate symex as a 'thunk,' i.e. as a function taking no arguments."


### PR DESCRIPTION
### Summary of Changes

Cider already has a pretty printing function ( `cider-pprint-eval-last-sexp`). Use this in `symex-eval-pretty-clojure` rather than the standard eval function.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
